### PR TITLE
fix: js plugin Unexpected token in JSON issues.

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -32,18 +32,18 @@
   "author": "<%=author%>",
   "license": "MIT",
   "devDependencies": {
-    "eslint": "^5.0.1",
-    "eslint-config-standard": "^11.0.0",
-    "eslint-plugin-import": "^2.13.0",
-    "eslint-plugin-node": "^6.0.1",
-    "eslint-plugin-promise": "^3.8.0",
-    "eslint-plugin-standard": "^3.1.0",
 <% if (type === 'ts') { -%>
     "@types/node": "^10.10.1",
     "picgo": "^1.2.0",
     "tslint": "^5.10.0",
     "tslint-config-standard": "^7.1.0",
-    "typescript": "^3.0.3"
+    "typescript": "^3.0.3",
 <% } -%>
+    "eslint": "^5.0.1",
+    "eslint-config-standard": "^11.0.0",
+    "eslint-plugin-import": "^2.13.0",
+    "eslint-plugin-node": "^6.0.1",
+    "eslint-plugin-promise": "^3.8.0",
+    "eslint-plugin-standard": "^3.1.0"
   }
 }


### PR DESCRIPTION
修复当创建的插件为js时，devDependencies最后一行有逗号，导致json格式不正确的问题。